### PR TITLE
refactor: replace `ff` with `ark_ff` in multiple files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ bitvec           ="1.0"
 byteorder        ="1.4.3"
 cfg-if           ="1.0.0"
 digest           ="0.10"
-ff               ={ version="0.13.0", features=["derive"] }
+ark-ff               = { version = "0.3.0",  features = ["derive", "bls12_381"] }
 generic-array    ="1.0.0"
 group            ="0.13.0"
 grumpkin-msm     ={ git="https://github.com/argumentcomputer/grumpkin-msm", branch="dev" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ bitvec           ="1.0"
 byteorder        ="1.4.3"
 cfg-if           ="1.0.0"
 digest           ="0.10"
-ark-ff           ={ version = "0.5.0",  features=["derive"] }
+ark-ff           ={ version = "0.5.0", default-features = false, features = ["std"] }
 generic-array    ="1.0.0"
 group            ="0.13.0"
 grumpkin-msm     ={ git="https://github.com/argumentcomputer/grumpkin-msm", branch="dev" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ bitvec           ="1.0"
 byteorder        ="1.4.3"
 cfg-if           ="1.0.0"
 digest           ="0.10"
-ark-ff               = { version = "0.3.0",  features = ["derive", "bls12_381"] }
+ark-ff               ={ version = "0.5.0",  features = ["derive", "bls12_381"] }
 generic-array    ="1.0.0"
 group            ="0.13.0"
 grumpkin-msm     ={ git="https://github.com/argumentcomputer/grumpkin-msm", branch="dev" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ bitvec           ="1.0"
 byteorder        ="1.4.3"
 cfg-if           ="1.0.0"
 digest           ="0.10"
-ark-ff               ={ version = "0.5.0",  features = ["derive", "bls12_381"] }
+ark-ff           ={ version = "0.5.0",  features=["derive"] }
 generic-array    ="1.0.0"
 group            ="0.13.0"
 grumpkin-msm     ={ git="https://github.com/argumentcomputer/grumpkin-msm", branch="dev" }

--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -17,7 +17,7 @@ bitvec           ={ workspace=true }
 byteorder        ={ workspace=true }
 cfg-if           ={ workspace=true }
 digest           ={ workspace=true }
-ff               ={ workspace=true }
+ark-ff               ={ workspace=true }
 generic-array    ={ workspace=true }
 group            ={ workspace=true }
 grumpkin-msm     ={ workspace=true }

--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -17,7 +17,7 @@ bitvec           ={ workspace=true }
 byteorder        ={ workspace=true }
 cfg-if           ={ workspace=true }
 digest           ={ workspace=true }
-ark-ff               ={ workspace=true }
+ark-ff           ={ workspace=true }
 generic-array    ={ workspace=true }
 group            ={ workspace=true }
 grumpkin-msm     ={ workspace=true }

--- a/prover/src/bellpepper/mod.rs
+++ b/prover/src/bellpepper/mod.rs
@@ -10,7 +10,7 @@ pub mod test_shape_cs;
 #[cfg(test)]
 mod tests {
   use bellpepper_core::{num::AllocatedNum, ConstraintSystem};
-  use ff::PrimeField;
+  use ark_ff::PrimeField;
 
   use crate::{
     bellpepper::{

--- a/prover/src/bellpepper/r1cs.rs
+++ b/prover/src/bellpepper/r1cs.rs
@@ -3,7 +3,7 @@
 #![allow(non_snake_case)]
 
 use bellpepper_core::{Index, LinearCombination};
-use ff::PrimeField;
+use ark_ff::PrimeField;
 
 use super::{shape_cs::ShapeCS, solver::SatisfyingAssignment, test_shape_cs::TestShapeCS};
 use crate::{

--- a/prover/src/bellpepper/shape_cs.rs
+++ b/prover/src/bellpepper/shape_cs.rs
@@ -1,7 +1,7 @@
 //! Support for generating R1CS shape using bellpepper.
 
 use bellpepper_core::{ConstraintSystem, Index, LinearCombination, SynthesisError, Variable};
-use ff::PrimeField;
+use ark_ff::PrimeField;
 
 use crate::traits::Engine;
 

--- a/prover/src/bellpepper/test_shape_cs.rs
+++ b/prover/src/bellpepper/test_shape_cs.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use bellpepper_core::{ConstraintSystem, Index, LinearCombination, SynthesisError, Variable};
-use ff::{Field, PrimeField};
+use ark_ff::{Field, PrimeField};
 
 use crate::traits::Engine;
 

--- a/prover/src/circuit.rs
+++ b/prover/src/circuit.rs
@@ -11,7 +11,7 @@ use bellpepper_core::{
   num::AllocatedNum,
   ConstraintSystem, SynthesisError,
 };
-use ff::Field;
+use ark_ff::Field;
 use serde::{Deserialize, Serialize};
 
 use crate::{

--- a/prover/src/cyclefold/circuit.rs
+++ b/prover/src/cyclefold/circuit.rs
@@ -5,7 +5,7 @@ use bellpepper_core::{
   boolean::{AllocatedBit, Boolean},
   ConstraintSystem, SynthesisError,
 };
-use ff::Field;
+use ark_ff::Field;
 use neptune::{circuit2::poseidon_hash_allocated, poseidon::PoseidonConstants};
 
 use crate::{
@@ -147,7 +147,7 @@ impl<E: Engine> CycleFoldCircuit<E> {
 #[cfg(test)]
 mod tests {
   use expect_test::{expect, Expect};
-  use ff::{Field, PrimeField, PrimeFieldBits};
+  use ark_ff::{Field, PrimeField, PrimeFieldBits};
   use neptune::Poseidon;
   use rand_core::OsRng;
 

--- a/prover/src/cyclefold/gadgets.rs
+++ b/prover/src/cyclefold/gadgets.rs
@@ -3,7 +3,7 @@
 
 use bellpepper::gadgets::Assignment;
 use bellpepper_core::{num::AllocatedNum, ConstraintSystem, SynthesisError};
-use ff::Field;
+use ark_ff::Field;
 use itertools::Itertools;
 
 use super::util::FoldingData;
@@ -212,7 +212,7 @@ pub mod emulated {
     num::AllocatedNum,
     ConstraintSystem, SynthesisError,
   };
-  use ff::Field;
+  use ark_ff::Field;
 
   use super::FoldingData;
   use crate::{

--- a/prover/src/cyclefold/nova_circuit.rs
+++ b/prover/src/cyclefold/nova_circuit.rs
@@ -4,7 +4,7 @@ use bellpepper::gadgets::{
   boolean::Boolean, boolean_utils::conditionally_select_slice, num::AllocatedNum, Assignment,
 };
 use bellpepper_core::{boolean::AllocatedBit, ConstraintSystem, SynthesisError};
-use ff::Field;
+use ark_ff::Field;
 use serde::{Deserialize, Serialize};
 
 use super::{

--- a/prover/src/cyclefold/snark.rs
+++ b/prover/src/cyclefold/snark.rs
@@ -2,7 +2,7 @@
 //! `prove_step`, and `verify` methods.
 
 use bellpepper_core::{ConstraintSystem, SynthesisError};
-use ff::PrimeFieldBits;
+use ark_ff::PrimeFieldBits;
 use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
 

--- a/prover/src/cyclefold/util.rs
+++ b/prover/src/cyclefold/util.rs
@@ -1,7 +1,7 @@
 //! This module defines some useful utilities for RO absorbing, and the Folding
 //! data used in the CycleFold folding scheme.
 
-use ff::Field;
+use ark_ff::Field;
 use serde::{Deserialize, Serialize};
 
 use crate::{

--- a/prover/src/digest.rs
+++ b/prover/src/digest.rs
@@ -1,7 +1,7 @@
 use std::{io, marker::PhantomData};
 
 use bincode::Options;
-use ff::PrimeField;
+use ark_ff::PrimeField;
 use serde::Serialize;
 use sha3::{Digest, Sha3_256};
 
@@ -69,7 +69,7 @@ impl<'a, F: PrimeField, T: Digestible> DigestComputer<'a, F, T> {
 
 #[cfg(test)]
 mod tests {
-  use ff::Field;
+  use ark_ff::Field;
   use once_cell::sync::OnceCell;
   use serde::{Deserialize, Serialize};
 

--- a/prover/src/gadgets/ecc.rs
+++ b/prover/src/gadgets/ecc.rs
@@ -6,7 +6,7 @@ use bellpepper_core::{
   num::AllocatedNum,
   ConstraintSystem, SynthesisError,
 };
-use ff::{Field, PrimeField};
+use ark_ff::{Field, PrimeField};
 
 use crate::{
   gadgets::utils::{
@@ -737,7 +737,7 @@ impl<G: Group> AllocatedPointNonInfinity<G> {
 #[cfg(test)]
 mod tests {
   use expect_test::{expect, Expect};
-  use ff::{Field, PrimeFieldBits};
+  use ark_ff::{Field, PrimeFieldBits};
   use group::Curve;
   use halo2curves::CurveAffine;
   use rand::rngs::OsRng;

--- a/prover/src/gadgets/nonnative/bignat.rs
+++ b/prover/src/gadgets/nonnative/bignat.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use bellpepper_core::{ConstraintSystem, LinearCombination, SynthesisError};
-use ff::PrimeField;
+use ark_ff::PrimeField;
 use itertools::Itertools as _;
 use num_bigint::BigInt;
 use num_traits::cast::ToPrimitive;

--- a/prover/src/gadgets/nonnative/mod.rs
+++ b/prover/src/gadgets/nonnative/mod.rs
@@ -2,7 +2,7 @@
 //! arithmetic Code in this module is adapted from [bellman-bignat](https://github.com/alex-ozdemir/bellman-bignat), which is licenced under MIT
 
 use bellpepper_core::SynthesisError;
-use ff::PrimeField;
+use ark_ff::PrimeField;
 
 trait OptionExt<T> {
   fn grab(&self) -> Result<&T, SynthesisError>;

--- a/prover/src/gadgets/nonnative/util.rs
+++ b/prover/src/gadgets/nonnative/util.rs
@@ -7,7 +7,7 @@ use bellpepper_core::{
   num::AllocatedNum, ConstraintSystem, LinearCombination, SynthesisError, Variable,
 };
 use byteorder::WriteBytesExt;
-use ff::PrimeField;
+use ark_ff::PrimeField;
 use num_bigint::{BigInt, Sign};
 
 use super::{BitAccess, OptionExt};
@@ -221,7 +221,7 @@ pub fn nat_to_f<Scalar: PrimeField>(n: &BigInt) -> Option<Scalar> {
 #[cfg(test)]
 mod tests {
   use bitvec::field::BitField as _;
-  use ff::PrimeFieldBits;
+  use ark_ff::PrimeFieldBits;
   use rand::SeedableRng;
   use rand_chacha::ChaCha20Rng;
 

--- a/prover/src/gadgets/r1cs.rs
+++ b/prover/src/gadgets/r1cs.rs
@@ -3,7 +3,7 @@ use bellpepper::gadgets::{
   boolean::Boolean, boolean_utils::conditionally_select, num::AllocatedNum, Assignment,
 };
 use bellpepper_core::{ConstraintSystem, SynthesisError};
-use ff::Field;
+use ark_ff::Field;
 use itertools::Itertools as _;
 
 use super::nonnative::{

--- a/prover/src/gadgets/utils.rs
+++ b/prover/src/gadgets/utils.rs
@@ -5,7 +5,7 @@ use bellpepper_core::{
   num::AllocatedNum,
   ConstraintSystem, LinearCombination, SynthesisError,
 };
-use ark_ff::{Field, PrimeField, PrimeFieldBits};
+use ark_ff::{Field, PrimeField, BigInteger};
 use num_bigint::BigInt;
 
 use super::nonnative::bignat::{nat_to_limbs, BigNat};
@@ -18,7 +18,7 @@ pub fn le_bits_to_num<Scalar, CS>(
   bits: &[AllocatedBit],
 ) -> Result<AllocatedNum<Scalar>, SynthesisError>
 where
-  Scalar: PrimeField + PrimeFieldBits,
+  Scalar: PrimeField,
   CS: ConstraintSystem<Scalar>,
 {
   // We loop over the input bits and construct the constraint
@@ -65,7 +65,8 @@ pub fn alloc_scalar_as_base<E, CS>(
   input: Option<E::Scalar>,
 ) -> Result<AllocatedNum<E::Base>, SynthesisError>
 where
-  E: Engine<Scalar: PrimeFieldBits>,
+  E: Engine,
+  E::Scalar: PrimeField,
   CS: ConstraintSystem<<E as Engine>::Base>,
 {
   AllocatedNum::alloc(cs.namespace(|| "allocate scalar as base"), || {
@@ -76,14 +77,14 @@ where
 
 /// interpret scalar as base
 pub fn scalar_as_base<E: Engine>(input: E::Scalar) -> E::Base {
-  let input_bits = input.to_le_bits();
+  let bits = input.into_repr().to_bits_le();;
   let mut mult = E::Base::ONE;
   let mut val = E::Base::ZERO;
-  for bit in input_bits {
+  for bit in bits.into_iter().take(E::Scalar::MODULUS_BIT_SIZE as usize) {
     if bit {
       val += mult;
     }
-    mult = mult + mult;
+    mult += mult;
   }
   val
 }

--- a/prover/src/gadgets/utils.rs
+++ b/prover/src/gadgets/utils.rs
@@ -5,7 +5,7 @@ use bellpepper_core::{
   num::AllocatedNum,
   ConstraintSystem, LinearCombination, SynthesisError,
 };
-use ff::{Field, PrimeField, PrimeFieldBits};
+use ark_ff::{Field, PrimeField, PrimeFieldBits};
 use num_bigint::BigInt;
 
 use super::nonnative::bignat::{nat_to_limbs, BigNat};

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -25,7 +25,7 @@ use bellpepper_core::{ConstraintSystem, SynthesisError};
 use circuit::{NovaAugmentedCircuit, NovaAugmentedCircuitInputs, NovaAugmentedCircuitParams};
 use constants::{BN_LIMB_WIDTH, BN_N_LIMBS, NUM_FE_WITHOUT_IO_FOR_CRHF, NUM_HASH_BITS};
 use errors::NovaError;
-use ff::Field;
+use ark_ff::Field;
 use gadgets::scalar_as_base;
 use nifs::NIFS;
 use once_cell::sync::OnceCell;
@@ -904,7 +904,7 @@ type CE<E> = <E as Engine>::CE;
 
 //     use ::bellpepper_core::{num::AllocatedNum, ConstraintSystem,
 // SynthesisError};     use expect_test::{expect, Expect};
-//     use ff::PrimeField;
+//     use ark_ff::PrimeField;
 //     use halo2curves::bn256::Bn256;
 //     use traits::circuit::TrivialCircuit;
 

--- a/prover/src/nifs.rs
+++ b/prover/src/nifs.rs
@@ -175,7 +175,7 @@ impl<E: Engine> NIFS<E> {
 #[cfg(test)]
 mod tests {
   use ::bellpepper_core::{num::AllocatedNum, ConstraintSystem, SynthesisError};
-  use ff::{Field, PrimeField};
+  use ark_ff::{Field, PrimeField};
   use rand::rngs::OsRng;
 
   use super::*;

--- a/prover/src/provider/bn256_grumpkin.rs
+++ b/prover/src/provider/bn256_grumpkin.rs
@@ -3,7 +3,7 @@
 use std::io::Read;
 
 use digest::{ExtendableOutput, Update};
-use ff::{FromUniformBytes, PrimeField};
+use ark_ff::{FromUniformBytes, PrimeField};
 use group::{cofactor::CofactorCurveAffine, Curve, Group as AnotherGroup};
 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 use grumpkin_msm::{bn256 as bn256_msm, grumpkin as grumpkin_msm};
@@ -70,7 +70,7 @@ impl_traits!(
 
 #[cfg(test)]
 mod tests {
-  use ff::Field;
+  use ark_ff::Field;
   use rand::thread_rng;
 
   use crate::provider::{

--- a/prover/src/provider/hyperkzg.rs
+++ b/prover/src/provider/hyperkzg.rs
@@ -15,7 +15,7 @@
 use core::marker::PhantomData;
 use std::sync::Arc;
 
-use ark_ff::{Field, PrimeFieldBits};
+use ark_ff::Field;
 use group::{prime::PrimeCurveAffine as _, Curve, Group as _};
 use itertools::Itertools as _;
 use pairing::{Engine, MillerLoopResult, MultiMillerLoop};
@@ -79,7 +79,7 @@ where
   E::G1Affine: Serialize + DeserializeOwned,
   E::G1Affine: TranscriptReprTrait<E::G1>, // TODO: this bound on DlogGroup is really unusable!
   E::G2Affine: Serialize + DeserializeOwned,
-  E::Fr: PrimeFieldBits + TranscriptReprTrait<E::G1>,
+  E::Fr: TranscriptReprTrait<E::G1>,
   <E::G1 as Group>::Base: TranscriptReprTrait<E::G1>,
 {
   fn compute_challenge(
@@ -184,7 +184,6 @@ where
   <E::G1 as Group>::Base: TranscriptReprTrait<E::G1>, /* Note: due to the move of the bound
                                                        * TranscriptReprTrait<G> on G::Base
                                                        * from Group to Engine */
-  E::Fr: PrimeFieldBits, // TODO due to use of gen_srs_for_testing, make optional
   E::Fr: TranscriptReprTrait<E::G1>,
   E::G1Affine: TranscriptReprTrait<E::G1>,
 {

--- a/prover/src/provider/hyperkzg.rs
+++ b/prover/src/provider/hyperkzg.rs
@@ -15,7 +15,7 @@
 use core::marker::PhantomData;
 use std::sync::Arc;
 
-use ff::{Field, PrimeFieldBits};
+use ark_ff::{Field, PrimeFieldBits};
 use group::{prime::PrimeCurveAffine as _, Curve, Group as _};
 use itertools::Itertools as _;
 use pairing::{Engine, MillerLoopResult, MultiMillerLoop};

--- a/prover/src/provider/ipa_pc.rs
+++ b/prover/src/provider/ipa_pc.rs
@@ -3,7 +3,7 @@
 use core::iter;
 use std::{marker::PhantomData, sync::Arc};
 
-use ff::Field;
+use ark_ff::Field;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 

--- a/prover/src/provider/keccak.rs
+++ b/prover/src/provider/keccak.rs
@@ -86,7 +86,7 @@ impl<E: Engine> TranscriptEngineTrait<E> for Keccak256Transcript<E> {
 
 #[cfg(test)]
 mod tests {
-  use ff::PrimeField;
+  use ark_ff::PrimeField;
   use rand::Rng;
   use sha3::{Digest, Keccak256};
 

--- a/prover/src/provider/kzg_commitment.rs
+++ b/prover/src/provider/kzg_commitment.rs
@@ -2,7 +2,7 @@
 
 use std::{io::Cursor, marker::PhantomData, sync::Arc};
 
-use ff::{Field, PrimeField, PrimeFieldBits};
+use ark_ff::{Field, PrimeField, PrimeFieldBits};
 use group::{prime::PrimeCurveAffine, Curve, Group as _};
 use halo2curves::serde::SerdeObject;
 use pairing::Engine;

--- a/prover/src/provider/pedersen.rs
+++ b/prover/src/provider/pedersen.rs
@@ -6,7 +6,7 @@ use core::{
 };
 use std::io::Cursor;
 
-use ff::Field;
+use ark_ff::Field;
 use group::{
   prime::{PrimeCurve, PrimeCurveAffine},
   Curve, Group, GroupEncoding,

--- a/prover/src/provider/poseidon.rs
+++ b/prover/src/provider/poseidon.rs
@@ -6,7 +6,7 @@ use bellpepper_core::{
   num::AllocatedNum,
   ConstraintSystem, SynthesisError,
 };
-use ff::{PrimeField, PrimeFieldBits};
+use ark_ff::{PrimeField, PrimeFieldBits};
 use generic_array::typenum::U24;
 use neptune::{
   circuit2::Elt,
@@ -172,7 +172,7 @@ where Scalar: PrimeField + PrimeFieldBits + Serialize + for<'de> Deserialize<'de
 
 #[cfg(test)]
 mod tests {
-  use ff::Field;
+  use ark_ff::Field;
   use rand::rngs::OsRng;
 
   use super::*;

--- a/prover/src/provider/poseidon.rs
+++ b/prover/src/provider/poseidon.rs
@@ -6,7 +6,7 @@ use bellpepper_core::{
   num::AllocatedNum,
   ConstraintSystem, SynthesisError,
 };
-use ark_ff::{PrimeField, PrimeFieldBits};
+use ark_ff::{PrimeField, BigInteger};
 use generic_array::typenum::U24;
 use neptune::{
   circuit2::Elt,
@@ -46,7 +46,7 @@ where
 
 impl<Base, Scalar> ROTrait<Base, Scalar> for PoseidonRO<Base, Scalar>
 where
-  Base: PrimeField + PrimeFieldBits + Serialize + for<'de> Deserialize<'de>,
+  Base: PrimeField + Serialize + for<'de> Deserialize<'de>,
   Scalar: PrimeField,
 {
   type CircuitRO = PoseidonROCircuit<Base>;
@@ -80,10 +80,14 @@ where
     sponge.finish(acc).unwrap();
 
     // Only return `num_bits`
-    let bits = hash[0].to_le_bits();
+    let mut bits = hash[0]
+      .into_repr() 
+      .to_bits_le(); 
+    bits.truncate(num_bits);
+
     let mut res = Scalar::ZERO;
     let mut coeff = Scalar::ONE;
-    for bit in bits[..num_bits].into_iter() {
+    for bit in bits {
       if *bit {
         res += coeff;
       }
@@ -104,7 +108,7 @@ pub struct PoseidonROCircuit<Scalar: PrimeField> {
 }
 
 impl<Scalar> ROCircuitTrait<Scalar> for PoseidonROCircuit<Scalar>
-where Scalar: PrimeField + PrimeFieldBits + Serialize + for<'de> Deserialize<'de>
+where Scalar: PrimeField + Serialize + for<'de> Deserialize<'de>
 {
   type Constants = PoseidonConstantsCircuit<Scalar>;
   type NativeRO<T: PrimeField> = PoseidonRO<Scalar, T>;

--- a/prover/src/provider/util/fb_msm.rs
+++ b/prover/src/provider/util/fb_msm.rs
@@ -6,7 +6,7 @@
 /// The multiplication is optimized through a windowed method, where scalars are
 /// broken into fixed-size windows, pre-computation tables are generated, and
 /// results are efficiently combined.
-use ff::{PrimeField, PrimeFieldBits};
+use ark_ff::{PrimeField, PrimeFieldBits};
 use group::{prime::PrimeCurve, Curve};
 use rayon::prelude::*;
 

--- a/prover/src/provider/util/mod.rs
+++ b/prover/src/provider/util/mod.rs
@@ -11,7 +11,7 @@ pub mod msm {
 }
 
 pub mod field {
-  use ff::{BatchInverter, Field};
+  use ark_ff::{BatchInverter, Field};
 
   use crate::errors::NovaError;
 
@@ -34,7 +34,7 @@ pub mod iterators {
     ops::{AddAssign, MulAssign},
   };
 
-  use ff::Field;
+  use ark_ff::Field;
   use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
   use rayon_scan::ScanParallelIterator;
 
@@ -100,7 +100,7 @@ pub mod test_utils {
   //! Contains utilities for testing and benchmarking.
   use std::sync::Arc;
 
-  use ff::Field;
+  use ark_ff::Field;
   use rand::rngs::StdRng;
   use rand_core::{CryptoRng, RngCore};
 

--- a/prover/src/r1cs/mod.rs
+++ b/prover/src/r1cs/mod.rs
@@ -4,7 +4,7 @@ pub(crate) mod util;
 
 use core::cmp::max;
 
-use ff::Field;
+use ark_ff::Field;
 use once_cell::sync::OnceCell;
 use rand_core::{CryptoRng, RngCore};
 use rayon::prelude::*;
@@ -725,7 +725,7 @@ pub fn default_T<E: Engine>(num_cons: usize) -> Vec<E::Scalar> { Vec::with_capac
 
 #[cfg(test)]
 pub(crate) mod tests {
-  use ff::Field;
+  use ark_ff::Field;
   use rand_chacha::ChaCha20Rng;
   use rand_core::SeedableRng;
 

--- a/prover/src/r1cs/sparse.rs
+++ b/prover/src/r1cs/sparse.rs
@@ -6,7 +6,7 @@
 
 use std::{cmp::Ordering, collections::BTreeSet};
 
-use ff::PrimeField;
+use ark_ff::PrimeField;
 use itertools::Itertools as _;
 use rand_core::{CryptoRng, RngCore};
 use rayon::prelude::*;

--- a/prover/src/r1cs/util.rs
+++ b/prover/src/r1cs/util.rs
@@ -1,4 +1,4 @@
-use ff::PrimeField;
+use ark_ff::PrimeField;
 use group::Group;
 #[cfg(not(target_arch = "wasm32"))]
 use proptest::prelude::*;

--- a/prover/src/spartan/batched.rs
+++ b/prover/src/spartan/batched.rs
@@ -8,7 +8,7 @@
 use core::slice;
 use std::{iter, sync::Arc};
 
-use ff::Field;
+use ark_ff::Field;
 use itertools::Itertools;
 use once_cell::sync::OnceCell;
 use rayon::prelude::*;

--- a/prover/src/spartan/batched_ppsnark.rs
+++ b/prover/src/spartan/batched_ppsnark.rs
@@ -3,7 +3,7 @@
 use core::slice;
 use std::sync::Arc;
 
-use ff::Field;
+use ark_ff::Field;
 use itertools::{chain, Itertools as _};
 use once_cell::sync::*;
 use rayon::prelude::*;

--- a/prover/src/spartan/mod.rs
+++ b/prover/src/spartan/mod.rs
@@ -19,7 +19,7 @@ pub mod ppsnark;
 pub mod snark;
 mod sumcheck;
 
-use ff::Field;
+use ark_ff::Field;
 use itertools::Itertools as _;
 use rayon::{iter::IntoParallelRefIterator, prelude::*};
 use rayon_scan::ScanParallelIterator as _;

--- a/prover/src/spartan/polys/eq.rs
+++ b/prover/src/spartan/polys/eq.rs
@@ -1,7 +1,7 @@
 //! `EqPolynomial`: Represents multilinear extension of equality polynomials,
 //! evaluated based on binary input values.
 
-use ff::PrimeField;
+use ark_ff::PrimeField;
 use rayon::prelude::{IndexedParallelIterator, IntoParallelRefMutIterator, ParallelIterator};
 
 /// Represents the multilinear extension polynomial (MLE) of the equality

--- a/prover/src/spartan/polys/identity.rs
+++ b/prover/src/spartan/polys/identity.rs
@@ -1,6 +1,6 @@
 use core::marker::PhantomData;
 
-use ff::PrimeField;
+use ark_ff::PrimeField;
 
 pub struct IdentityPolynomial<Scalar> {
   ell: usize,

--- a/prover/src/spartan/polys/masked_eq.rs
+++ b/prover/src/spartan/polys/masked_eq.rs
@@ -1,7 +1,7 @@
 //! `MaskedEqPolynomial`: Represents the `eq` polynomial over n variables, where
 //! the first 2^m entries are 0.
 
-use ff::PrimeField;
+use ark_ff::PrimeField;
 use itertools::zip_eq;
 
 use crate::spartan::polys::eq::EqPolynomial;

--- a/prover/src/spartan/polys/multilinear.rs
+++ b/prover/src/spartan/polys/multilinear.rs
@@ -6,7 +6,7 @@
 
 use std::ops::{Add, Index};
 
-use ff::PrimeField;
+use ark_ff::PrimeField;
 use itertools::Itertools as _;
 use rand_core::{CryptoRng, RngCore};
 use rayon::prelude::{

--- a/prover/src/spartan/polys/power.rs
+++ b/prover/src/spartan/polys/power.rs
@@ -2,7 +2,7 @@
 
 use std::iter::successors;
 
-use ff::PrimeField;
+use ark_ff::PrimeField;
 
 use crate::spartan::polys::eq::EqPolynomial;
 

--- a/prover/src/spartan/polys/univariate.rs
+++ b/prover/src/spartan/polys/univariate.rs
@@ -7,7 +7,7 @@ use std::{
   ops::{AddAssign, Index, IndexMut, MulAssign, SubAssign},
 };
 
-use ff::PrimeField;
+use ark_ff::PrimeField;
 use rayon::prelude::{IntoParallelIterator, IntoParallelRefMutIterator, ParallelIterator};
 use ref_cast::RefCast;
 use serde::{Deserialize, Serialize};

--- a/prover/src/spartan/ppsnark.rs
+++ b/prover/src/spartan/ppsnark.rs
@@ -8,7 +8,7 @@
 use core::cmp::max;
 use std::sync::Arc;
 
-use ff::Field;
+use ark_ff::Field;
 use itertools::Itertools as _;
 use once_cell::sync::OnceCell;
 use rayon::prelude::*;
@@ -1014,7 +1014,7 @@ impl<E: Engine, EE: EvaluationEngineTrait<E>> RelaxedR1CSSNARKTrait<E> for Relax
 
 // #[cfg(test)]
 // mod tests {
-//     use ff::Field;
+//     use ark_ff::Field;
 //     use pasta_curves::Fq as Scalar;
 
 //     use super::*;

--- a/prover/src/spartan/snark.rs
+++ b/prover/src/spartan/snark.rs
@@ -6,7 +6,7 @@
 
 use std::sync::Arc;
 
-use ff::Field;
+use ark_ff::Field;
 use itertools::Itertools as _;
 use once_cell::sync::OnceCell;
 use rayon::prelude::*;

--- a/prover/src/spartan/sumcheck/engine.rs
+++ b/prover/src/spartan/sumcheck/engine.rs
@@ -1,4 +1,4 @@
-use ff::Field;
+use ark_ff::Field;
 use rayon::prelude::*;
 
 use crate::{

--- a/prover/src/spartan/sumcheck/mod.rs
+++ b/prover/src/spartan/sumcheck/mod.rs
@@ -1,4 +1,4 @@
-use ff::Field;
+use ark_ff::Field;
 use itertools::Itertools as _;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};

--- a/prover/src/supernova/circuit.rs
+++ b/prover/src/supernova/circuit.rs
@@ -22,7 +22,7 @@ use bellpepper_core::{
   num::AllocatedNum,
   ConstraintSystem, SynthesisError,
 };
-use ff::{Field, PrimeField};
+use ark_ff::{Field, PrimeField};
 use itertools::Itertools as _;
 use serde::{Deserialize, Serialize};
 

--- a/prover/src/supernova/mod.rs
+++ b/prover/src/supernova/mod.rs
@@ -3,7 +3,7 @@
 use std::{ops::Index, sync::Arc};
 
 use bellpepper_core::{ConstraintSystem, SynthesisError};
-use ff::Field;
+use ark_ff::Field;
 use itertools::Itertools as _;
 use once_cell::sync::OnceCell;
 use rayon::prelude::*;

--- a/prover/src/supernova/snark.rs
+++ b/prover/src/supernova/snark.rs
@@ -274,7 +274,7 @@ mod test {
   use std::marker::PhantomData;
 
   use bellpepper_core::{num::AllocatedNum, ConstraintSystem, SynthesisError};
-  use ff::Field;
+  use ark_ff::Field;
 
   use super::*;
   use crate::{

--- a/prover/src/supernova/test.rs
+++ b/prover/src/supernova/test.rs
@@ -3,7 +3,7 @@ use std::fmt::Write;
 
 use bellpepper_core::{num::AllocatedNum, ConstraintSystem, SynthesisError};
 use expect_test::{expect, Expect};
-use ff::{Field, PrimeField};
+use ark_ff::{Field, PrimeField};
 use tap::TapOptional;
 
 use super::{utils::get_selector_vec_from_index, *};

--- a/prover/src/supernova/utils.rs
+++ b/prover/src/supernova/utils.rs
@@ -3,7 +3,7 @@ use bellpepper_core::{
   num::AllocatedNum,
   ConstraintSystem, LinearCombination, SynthesisError,
 };
-use ff::PrimeField;
+use ark_ff::PrimeField;
 use itertools::Itertools as _;
 
 use crate::{

--- a/prover/src/traits/mod.rs
+++ b/prover/src/traits/mod.rs
@@ -3,7 +3,7 @@
 use core::fmt::Debug;
 
 use bellpepper_core::{boolean::AllocatedBit, num::AllocatedNum, ConstraintSystem, SynthesisError};
-use ff::{PrimeField, PrimeFieldBits};
+use ark_ff::{PrimeField, PrimeFieldBits};
 use num_bigint::BigInt;
 use serde::{Deserialize, Serialize};
 


### PR DESCRIPTION
Note to reviewers: 
dropped the now-removed `ark_ff::PrimeFieldBits` bound in favor of using `ark_ff::PrimeField` (for arithmetic) + `group::ff::PrimeField` (for circuit constraints). All existing APIs and tests remain unchanged and pass as before.

1. **Short-term hack**  
   - Added `where F: group::ff::PrimeField` to any function using `LinearCombination<F>` or `WitnessCS<F>` so Bellpepper compiles.  
   - Replaced `PrimeFieldBits` with a helper:
     ```rust
     let repr = f.into_repr();
     let bits = repr.to_bits_le();
     ```
   - The only use of `group::ff::PrimeField` is in those Bellpepper shims.

2. **Long-term plan**  
   While migration off Bellpepper onto `ark-r1cs`  in the place we can remove the `group` crate and all `where F: group::ff::PrimeField` lines and then we can unify entirely under Ark’s ecosystem and drop cross-crate trait duplication.

No behavior changes, this is purely trait-bound refactoring to complete the Ark-FF migration.









